### PR TITLE
Scaped characters double quotes on copy command

### DIFF
--- a/Compiling Gui/Compiling Gui/mainWindow.vb
+++ b/Compiling Gui/Compiling Gui/mainWindow.vb
@@ -501,9 +501,9 @@ Public Class mainWindow
             objWriter.WriteLine()
         End If
 
-        objWriter.WriteLine("copy " + tempMapFile + ".bsp " + outputFolder)
-        objWriter.WriteLine("copy " + tempMapFile + ".pts " + outputFolder) 'pts files into output folder for engine pointfile builtin
-        objWriter.WriteLine("copy " + tempMapFile + ".lit " + outputFolder) 'lit files for coloured lighting
+        objWriter.WriteLine("copy " + tempMapFile + ".bsp " + """" + outputFolder + """")
+        objWriter.WriteLine("copy " + tempMapFile + ".pts " + """" + outputFolder + """") 'pts files into output folder for engine pointfile builtin
+        objWriter.WriteLine("copy " + tempMapFile + ".lit " + """" + outputFolder + """") 'lit files for coloured lighting
 
         If pauseAfterCompiling.Checked = True Then
             objWriter.WriteLine("pause")


### PR DESCRIPTION
When the copy command is launched and routes have spaces in them the copy command fails. Adding double quotes solves this issue